### PR TITLE
Propagate retcode from Pytest execution

### DIFF
--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -220,8 +220,9 @@ def main():
     env = update_env(os.environ, bindir)
     cmd = pytest_cmd(args.test_group, skiplist, config, args.pytest_args)
     print("Running:", " ".join(cmd))
-    subprocess.run(
+    pytest_retcode = subprocess.run(
         cmd,
         env=env,
         cwd=cwd,
-    )
+    ).returncode
+    sys.exit(pytest_retcode)


### PR DESCRIPTION
With this PR, the retcode from the Pytest execution is propagated and provided as retcode for the `salt-test` script execution.

This helps to provide better feedback in a Jenkins pipeline when test execution fails.