### PR TITLE
Integration tests are slow

### DIFF
--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -21,7 +21,7 @@ except ImportError:
 
 DEFAULT_CONFIG = {
     "unit": {"dirs": ["tests/unit/", "tests/pytests/unit/"], "pytest_args": []},
-    "functional": {"dirs": ["tests/pytests/functional"], "pytest_args": []},
+    "functional": {"dirs": ["tests/pytests/functional"], "pytest_args": ["--slow"]},
     "integration": {
         "dirs": ["tests/integration/", "tests/pytests/integration/"],
         "pytest_args": ["--slow"],

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -24,7 +24,7 @@ DEFAULT_CONFIG = {
     "functional": {"dirs": ["tests/pytests/functional"], "pytest_args": []},
     "integration": {
         "dirs": ["tests/integration/", "tests/pytests/integration/"],
-        "pytest_args": [],
+        "pytest_args": ["--slow"],
     },
     "scenarios": {"dirs": ["tests/pytests/scenarios/"], "pytest_args": ["--slow"]},
 }

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -1,4 +1,5 @@
 """Run Salt Test Suite by test group."""
+
 import os
 import pathlib
 import re
@@ -6,8 +7,7 @@ import subprocess
 import sys
 import typing
 import urllib.request
-from argparse import ArgumentParser, FileType
-from collections import defaultdict
+from argparse import ArgumentParser
 
 try:
     import tomllib  # available in Python 3.11+


### PR DESCRIPTION
Most integration tests need `--slow`, let's add it as the default.