### PR TITLE
Clean bundle ENV vars for classic execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 **/*.egg-info/
 **/__pycache__/
 build/
+
+.vscode
+*.un~

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="salt-test",
-    version="1.3",
+    version="1.4",
     install_requires=["tomli;python_version<'3.11'"],
     package_dir={"": "src"},  # not needed for setuptools >= 61
     packages=find_packages("src"),

--- a/tests/test_salt_test.py
+++ b/tests/test_salt_test.py
@@ -2,7 +2,6 @@
 import argparse
 import io
 
-import pytest
 import salt_test
 
 


### PR DESCRIPTION
On both classic and Bundle testsuites, we currently use the `venv` salt-test.

Previously, classic execution would get env variables from `/usr/lib/venv-salt-minion/bin/python`:

```
#!/bin/sh

export VIRTUAL_ENV="/usr/lib/venv-salt-minion"
export VENV_PIP_TARGET="${VENV_PIP_TARGET:-/var/lib/venv-salt-minion/local}"
export PATH="$VIRTUAL_ENV/bin:$PATH"
export LD_LIBRARY_PATH="$VIRTUAL_ENV/lib"
export PYTHONHOME="$VIRTUAL_ENV"
export PYTHONSTARTUP="$VIRTUAL_ENV/bin/venv-startup"
export PYTHONPATH="$VENV_PIP_TARGET"
export SALT_CONFIG_DIR="/etc/venv-salt-minion"
export CPATH="${CPATH:-/usr/lib/venv-salt-minion/usr/include/python3.11}"

exec "$VIRTUAL_ENV/bin/python.original" "$@"
```

In this PR, we only pass those vars when we execute bundle. We clear those vars when executing classic, and rely on the default discovery mechanisms.