### PR TITLE
Do not hardcode python3 for classic salt

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="salt-test",
-    version="1.4",
+    version="1.5",
     install_requires=["tomli;python_version<'3.11'"],
     package_dir={"": "src"},  # not needed for setuptools >= 61
     packages=find_packages("src"),


### PR DESCRIPTION
Currently, our SLM6.x pipelines are failing with classic testsuite with:

`Test suite for flavor "classic" not installed.`

That is because `python3-salt-testsuite` is no longer installed, but `python311-salt-testsuite`. Right now, we need to support both the 3.6 and 3.11 versions of the package.

Instead of hardcoding more python packages, this PR lets users to choose the python flavor explicitly.