### PR TITLE
Make failed URL downloads easier to understand

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="salt-test",
-    version="1.5",
+    version="1.6",
     install_requires=["tomli;python_version<'3.11'"],
     package_dir={"": "src"},  # not needed for setuptools >= 61
     packages=find_packages("src"),

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -222,7 +222,7 @@ def main():
                 with urllib.request.urlopen(args.config) as f:
                     config = parse_config(f)
             except HTTPError as e:
-                raise AttributeError(f"URL {args.config} is not available") from e
+                raise AttributeError(f"URL '{args.config}' is not available") from e
         else:
             with open(args.config, "rb") as f:
                 config = parse_config(f)
@@ -234,7 +234,7 @@ def main():
             with urllib.request.urlopen(args.skiplist) as f:
                 skiplist = parse_skiplist(f, config.keys())
         except HTTPError as e:
-            raise AttributeError(f"URL {args.skiplist} is not available") from e
+            raise AttributeError(f"URL '{args.skiplist}' is not available") from e
     else:
         with open(args.skiplist, "rb") as f:
             skiplist = parse_skiplist(f, config.keys())

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -6,6 +6,7 @@ import re
 import subprocess
 import sys
 import typing
+from urllib.error import HTTPError
 import urllib.request
 from argparse import ArgumentParser
 
@@ -217,8 +218,11 @@ def main():
 
     if args.config:
         if args.config.startswith("http"):
-            with urllib.request.urlopen(args.config) as f:
-                config = parse_config(f)
+            try:
+                with urllib.request.urlopen(args.config) as f:
+                    config = parse_config(f)
+            except HTTPError as e:
+                raise AttributeError(f"URL {args.config} is not available") from e
         else:
             with open(args.config, "rb") as f:
                 config = parse_config(f)
@@ -226,8 +230,11 @@ def main():
         config = DEFAULT_CONFIG
 
     if args.skiplist.startswith("http"):
-        with urllib.request.urlopen(args.skiplist) as f:
-            skiplist = parse_skiplist(f, config.keys())
+        try:
+            with urllib.request.urlopen(args.skiplist) as f:
+                skiplist = parse_skiplist(f, config.keys())
+        except HTTPError as e:
+            raise AttributeError(f"URL {args.skiplist} is not available") from e
     else:
         with open(args.skiplist, "rb") as f:
             skiplist = parse_skiplist(f, config.keys())


### PR DESCRIPTION
I was executing the following command:

```
/usr/bin/salt-test -f python313 --skiplist https://raw.githubusercontent.com/openSUSE/salt-^Cst-skiplist/main/skipped_tests.toml unit
```

Which resulted in the following exception:

```python
Traceback (most recent call last):
  File "/usr/bin/salt-test", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/salt_test/__init__.py", line 229, in main
    with urllib.request.urlopen(args.skiplist) as f:
         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/usr/lib64/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found
```

This was, to me, a bit confusing, because I wasn't sure what URL was incorrect. 

With this change, the exception is as follows:

```python
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/salt_test/__init__.py", line 234, in main
    with urllib.request.urlopen(args.skiplist) as f:
         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 189, in urlopen
    return opener.open(url, data, timeout)
           ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 495, in open
    response = meth(req, response)
  File "/usr/lib64/python3.13/urllib/request.py", line 604, in http_response
    response = self.parent.error(
        'http', request, response, code, msg, hdrs)
  File "/usr/lib64/python3.13/urllib/request.py", line 533, in error
    return self._call_chain(*args)
           ~~~~~~~~~~~~~~~~^^^^^^^
  File "/usr/lib64/python3.13/urllib/request.py", line 466, in _call_chain
    result = func(*args)
  File "/usr/lib64/python3.13/urllib/request.py", line 613, in http_error_default
    raise HTTPError(req.full_url, code, msg, hdrs, fp)
urllib.error.HTTPError: HTTP Error 404: Not Found

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/bin/salt-test", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/usr/lib/python3.13/site-packages/salt_test/__init__.py", line 237, in main
    raise AttributeError(f"URL {args.skiplist} is not available") from e
AttributeError: URL https://raw.githubusercontent.com/openSUSE/salt-^Cst-skiplist/main/skipped_tests.toml is not available
```

Which is better to me, because it specifically mentions the failing URL (and makes the URL mistake obvious).