### PR TITLE
Improve user experience

### DIFF
--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -139,9 +139,8 @@ def testsuite_root_to_bindir(root: str) -> str:
 def pytest_cmd(group: str, skiplist: dict, config: dict, extra_args: typing.List[str]):
     """Compose the correct command args for pytest."""
     cmd = ["pytest"]
-    if not extra_args:
-        extra_args = config[group]["pytest_args"]
-    cmd.extend(extra_args)
+    args = config[group]["pytest_args"] + extra_args
+    cmd.extend(args)
     for skipped_file in skiplist[group]["ignore"]:
         cmd.extend(["--ignore", skipped_file])
     for skipped_test in skiplist[group]["skip"]:
@@ -184,7 +183,9 @@ def prepare_argparser() -> ArgumentParser:
     parser.add_argument(
         "pytest_args",
         nargs="*",
-        help="Specify extra arguments for pytest, separated from 'test_group' by a single --.",
+        help="Specify extra arguments for pytest, separated from"
+        " 'test_group' by a single --. They are merged with"
+        " pytest_args specified in the config.",
     )
     return parser
 

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -1,8 +1,26 @@
-"""Run Salt Test Suite by test group."""
+"""Run Salt Test Suite by test group.
 
+Test groups are:
+- unit
+- functional
+- integration
+- scenarios
+
+Tests can be ignored or skipped by means of a skiplist TOML file. Ignored test files are
+not collected by pytest. Skipped tests are collected but not executed by pytest. It's
+recommended to skip tests only when needed and select them individually.
+
+A config can be used to set arguments to pass to pytest, as well as to define additional
+test groups.
+
+This pytest wrapper can execute different pytest Python flavors, including a special
+"bundle" flavor. The Python flavor for pytest corresponds to the Python flavor of the Salt
+test suite.
+"""
+
+import contextlib
 import io
 import os
-import pathlib
 import re
 import subprocess
 import sys
@@ -31,9 +49,6 @@ DEFAULT_CONFIG = {
     "scenarios": {"dirs": ["tests/pytests/scenarios/"], "pytest_args": ["--slow"]},
 }
 
-FLAVOR_RPM = {
-    "bundle": "venv-salt-minion-testsuite",
-}
 
 VENV_ENV_PARAMS = {
     "CPATH",
@@ -84,34 +99,54 @@ def parse_config(file: typing.BinaryIO):
     return config
 
 
-def find_testsuite_root(flavor: str) -> str:
-    """Find root of test suite based.
+def resolve_testsuite_flavor(flavor: str) -> str:
+    """Resolve flavor if it's a capability.
 
-    :param flavor: Either "bundle", or python version, e.g. "python3", "python311", etc.
+    Flavor could be "python3" without any installed package being called python3. This is
+    the case for openSUSE Tumbleweed, where a versioned flavor provides the RPM symbol
+    "python3".
     """
+    if flavor == "python3":
+        completed = subprocess.run(
+            ["rpm", "-q", "--whatprovides", "python3-salt-testsuite"],
+            stdout=subprocess.PIPE,
+            encoding="utf-8",
+            check=False,
+        )
+        if completed.returncode == 0:
+            return completed.stdout.split("-")[0]
+    return flavor
 
-    def _list_files(pkg: str) -> typing.List[str]:
-        try:
-            cp = subprocess.run(
-                ["rpm", "-q", "-l", pkg],
-                stdout=subprocess.PIPE,
-                encoding="utf-8",
-            )
-        except FileNotFoundError:
-            cp = subprocess.run(
-                ["dpkg", "-L", pkg],
-                stdout=subprocess.PIPE,
-                encoding="utf-8",
-            )
-        if cp.returncode != 0:
-            return []
-        return cp.stdout.split()
 
-    if flavor in FLAVOR_RPM:
-        pkg = FLAVOR_RPM[flavor]
+def flavor_filelist(flavor: str) -> typing.List[str]:
+    """Return filelist of a given flavor package (rpm or deb)."""
+    if flavor == "bundle":
+        pkg = "venv-salt-minion-testsuite"
     else:
         pkg = f"{flavor}-salt-testsuite"
-    pkg_files = _list_files(pkg)
+
+    rpm_cmd = ["rpm", "-q", "-l", pkg]
+    dpkg_cmd = ["dpkg", "-L", pkg]
+    filelist = []
+    for cmd in (rpm_cmd, dpkg_cmd):
+        with contextlib.suppress(FileNotFoundError):
+            completed = subprocess.run(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.DEVNULL,
+                encoding="utf-8",
+                check=False,
+            )
+            if completed.returncode == 0:
+                filelist = completed.stdout.split()
+                break
+
+    return filelist
+
+
+def find_testsuite_root(flavor: str) -> str:
+    """Find root of the Salt test suite for the given flavor."""
+    pkg_files = flavor_filelist(flavor)
     root = None
     for file in pkg_files:
         match = re.match(r"(/usr/lib/.*/site-packages/salt-testsuite)", file)
@@ -125,21 +160,48 @@ def find_testsuite_root(flavor: str) -> str:
     return root
 
 
-def testsuite_root_to_bindir(root: str) -> str:
-    """Compute /bin from the testsuite root.
+def flavor_pytest_cmd(flavor: str) -> typing.List[str]:
+    """Compute pytest command for a given Python flavor.
 
-    This is needed to use the correct pytest executable.
+    Different flavors can be co-installed, we should use the same Python flavor
+    for running `pytest` that is being tested.
     """
-    p = pathlib.Path(root)
-    while p.name != "lib":
-        p = p.parent
-    # p now ends with /lib, therefore bin is a sibling
-    return str(p.parent / "bin")
+    if flavor == "bundle":
+        return ["/usr/lib/venv-salt-minion/bin/pytest"]
+    else:
+        match = re.match(r"python(\d+)$", flavor)
+        if match is not None:
+            ver = match.groups()[0]
+            if len(ver) == 1:
+                return ["/usr/bin/python3", "-m", "pytest"]
+            else:
+                return [f"/usr/bin/pytest-{ver[0]}.{ver[1:]}"]
+    return ["/usr/bin/pytest"]
 
 
-def pytest_cmd(group: str, skiplist: dict, config: dict, extra_args: typing.List[str]):
-    """Compose the correct command args for pytest."""
-    cmd = ["pytest"]
+def pytest_cmd(
+    group: str,
+    skiplist: dict,
+    config: dict,
+    extra_args: typing.List[str],
+    flavor="bundle",
+):
+    """Compose the correct command for pytest.
+
+    The correct pytest command executes the test suite with the Python flavor
+    corresponding to the package flavor. It deselects and ignores the tests
+    according to the skiplist, and adds other cli args according to the config
+    and CLI invocation.
+
+    Args:
+      group: The group of tests to execute, e.g. 'unit', or 'integration', ...
+      skiplist: Dictionary that specifies files to ignore and tests to skip for the given
+        'group'.
+      config: Dictionary that specifies "pytest_args" for the given 'group'.
+      extra_args: Arguments to pass through to pytest. The are merged with the args from 'config'.
+      flavor: Used to determine the right pytest command, based on the Python flavor.
+    """
+    cmd = flavor_pytest_cmd(flavor)
     args = config[group]["pytest_args"] + extra_args
     cmd.extend(args)
     for skipped_file in skiplist[group]["ignore"]:
@@ -190,7 +252,7 @@ def prepare_argparser() -> ArgumentParser:
     return parser
 
 
-def update_env(env: os._Environ, bindir: str, cwd: str, is_classic=False) -> dict:
+def update_env(env: os._Environ, cwd: str, is_classic=False) -> dict:
     """Update PATH and PYTHONPATH env variables.
 
     PATH is modified to contain bindir as the first entry. This ensures that `pytest` can
@@ -199,13 +261,11 @@ def update_env(env: os._Environ, bindir: str, cwd: str, is_classic=False) -> dic
 
     Args:
       env: Original environment variables
-      bindir: Path to a the bin/ directory where pytest is located.
       cwd: Current working directory, determines where Python finds the Salt code base.
       is_classic: If True, the VENV_ENV_PARAMS environment variables are unset. Default: False
         This is required when the Salt Bundle's salt-test is used with --flavor=classic.
     """
     env_copy = env.copy()
-    env_copy["PATH"] = f"{bindir}:{env_copy['PATH']}"
     env_copy["PYTHONPATH"] = cwd
     if is_classic:
         for key in VENV_ENV_PARAMS:
@@ -246,8 +306,10 @@ def main():
     if args.package_flavor == "classic":
         args.package_flavor = "python3"
 
+    flavor = resolve_testsuite_flavor(args.package_flavor)
+
     try:
-        testsuite_root = find_testsuite_root(args.package_flavor)
+        testsuite_root = find_testsuite_root(flavor)
     except RuntimeError as e:
         print(e)
         sys.exit(1)
@@ -257,10 +319,10 @@ def main():
     else:
         cwd = testsuite_root
 
-    bindir = testsuite_root_to_bindir(testsuite_root)
-
-    env = update_env(os.environ, bindir, cwd, args.package_flavor != "bundle")
-    cmd = pytest_cmd(args.test_group, skiplist, config, args.pytest_args)
+    env = update_env(os.environ, cwd, args.package_flavor != "bundle")
+    cmd = pytest_cmd(
+        args.test_group, skiplist, config, args.pytest_args, flavor=args.package_flavor
+    )
     print("Running:", " ".join(cmd))
     pytest_retcode = subprocess.run(
         cmd,

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -86,17 +86,18 @@ def parse_skiplist(
 def parse_config(file: typing.BinaryIO):
     """Reads the config and returns a dictionary.
 
-    The dictionary fills in missing test groups to guarantee [] access.
+    The dictionary fills in missing test groups to guarantee [] access.
     """
     raw_dict = toml.load(file)
     # raw_dict: {groups: {$group: {"dirs": [...], "pytest_args": [...]}
 
-    config = {}
-    for group in raw_dict["groups"]:
-        config[group]["dirs"] = group["dirs"]
-        config[group]["pytest_args"] = group.get("pytest_args", [])
+    ret = {}
+    for group, config in raw_dict["groups"].items():
+        ret[group] = {}
+        ret[group]["dirs"] = config["dirs"]
+        ret[group]["pytest_args"] = config.get("pytest_args", [])
 
-    return config
+    return ret
 
 
 def resolve_testsuite_flavor(flavor: str) -> str:


### PR DESCRIPTION
This PR fixes a small issue when testing a non-primary Python flavor (e.g. python311 on Tumbleweed) and improves the user experience in the following ways:

- `--skiplist` is optional now, leaving it empty means nothing is skipped
- `--flavor=python3` expands to the primary Python flavor (e.g. python313 on Tumbleweed)
- Any `pytest_args` passed at the end are merged with `pytest_args` set in the config

Also, configs are now parsed correctly (I think this was never tested / used)