### PR TITLE
Move to "requests" to have transparent integration with "~/.netrc" tokens

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 setup(
     name="salt-test",
     version="1.6",
-    install_requires=["tomli;python_version<'3.11'"],
+    install_requires=["tomli;python_version<'3.11'", "requests"],
     package_dir={"": "src"},  # not needed for setuptools >= 61
     packages=find_packages("src"),
     entry_points={

--- a/src/salt_test/__init__.py
+++ b/src/salt_test/__init__.py
@@ -22,11 +22,10 @@ import contextlib
 import io
 import os
 import re
+import requests
 import subprocess
 import sys
 import typing
-from urllib.error import HTTPError
-import urllib.request
 from argparse import ArgumentParser
 
 try:
@@ -281,9 +280,11 @@ def main():
     if args.config:
         if args.config.startswith("http"):
             try:
-                with urllib.request.urlopen(args.config) as f:
-                    config = parse_config(f)
-            except HTTPError as e:
+                response = requests.get(args.config, stream=True)
+                response.raise_for_status()
+                response.raw.decode_content = True
+                config = parse_config(response.raw)
+            except requests.exceptions.HTTPError as e:
                 raise AttributeError(f"URL '{args.config}' is not available") from e
         else:
             with open(args.config, "rb") as f:
@@ -294,9 +295,11 @@ def main():
     if args.skiplist:
         if args.skiplist.startswith("http"):
             try:
-                with urllib.request.urlopen(args.skiplist) as f:
-                    skiplist = parse_skiplist(f, config.keys())
-            except HTTPError as e:
+                response = requests.get(args.skiplist, stream=True)
+                response.raise_for_status()
+                response.raw.decode_content = True
+                skiplist = parse_skiplist(response.raw, config.keys())
+            except requests.exceptions.HTTPError as e:
                 raise AttributeError(f"URL '{args.skiplist}' is not available") from e
         else:
             with open(args.skiplist, "rb") as f:


### PR DESCRIPTION
In order to prevent `Too many requests` errors when fetching the skiplist or config provided URLs, this PR switch from `urllib.request` to `requests` library.

The `requests` library integrates with the possible tokens defined at `~/.netrc`, so it can perform the requests using an authentication token. The `urllib.request` on the other hand doesn't integrate with `~/.netrc`.

This way, we should prevent rate limiting issue, as the limits for authenticated users is much higher than per unauthenticated.